### PR TITLE
Add few methods with raw return

### DIFF
--- a/marketplace_apis/ozon/endpoints.py
+++ b/marketplace_apis/ozon/endpoints.py
@@ -13,6 +13,7 @@
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 API_PATH = {
     # region postings
+    "list_fbo_postings": "v2/posting/fbo/list",
     "list_postings": "v3/posting/fbs/list",
     "get_posting_by_number": "v3/posting/fbs/get",
     "ship_posting": "v4/posting/fbs/ship",
@@ -28,5 +29,6 @@ API_PATH = {
     # region products
     "list_product_info": "v2/product/info/list",
     "list_product_attributes": "v3/products/info/attributes",
+    "list_product": "v2/product/list",
     # endregion
 }


### PR DESCRIPTION
### Added New API Endpoints and Corresponding Methods:
1. **Endpoint:** `"list_fbo_postings": "v2/posting/fbo/list"`
   - **Method:** `ozon.posting.methods.list_fbo_posting`
   - **Description:** Retrieves FBO postings from Ozon. Currently, only the `raw` data return is implemented.

2. **Endpoint:** `"list_product": "v2/product/list"`
   - **Method:** `ozon.posting.methods.list_product`
   - **Description:** Retrieves all products of the seller if no filters are provided. The existing `ozon.posting.methods.list_info` method cannot be called without filters, so users are unable to get a list of all products if no IDs/SKUs are provided. Currently, only the `raw` data return is implemented.

3. **Enhanced Methods:**
   - Added a `raw` data return option for the methods:
     - `ozon.posting.methods.list_info`
     - `ozon.posting.methods.list_attributes`

